### PR TITLE
Add support for PATCH and DELETE methods

### DIFF
--- a/sphinxcontrib/pecanwsme/rest.py
+++ b/sphinxcontrib/pecanwsme/rest.py
@@ -170,6 +170,8 @@ class RESTControllerDirective(rst.Directive):
 
         for method_name, http_method_name in [('post', 'post'),
                                               ('put', 'put'),
+                                              ('delete', 'delete'),
+                                              ('patch', 'patch'),
                                           ]:
             app.info('Checking %s for %s method' % (controller, method_name))
             method = getattr(controller, method_name, None)


### PR DESCRIPTION
While Sphinx supports both the DELETE and the PATCH HTTP methods, the WSME extension doesn't.

All credit goes to Haomeng Wang, by whom the solution was suggested:
https://bugs.launchpad.net/ironic/+bug/1261917

Fixes #10
