### PR TITLE
Fix formatting issue for docstrings without param list

### DIFF
--- a/sphinxcontrib/pecanwsme/rest.py
+++ b/sphinxcontrib/pecanwsme/rest.py
@@ -101,6 +101,10 @@ class RESTControllerDirective(rst.Directive):
             docstring.append(':type %s: %s' %
                              (arg.name, datatypename(arg.datatype)))
 
+        # Add a blank line before return type to avoid the formatting issues
+        # that are caused because of missing blank lines between blocks
+        docstring.append(blank_line)
+
         # Add the return type
         if funcdef.return_type:
             return_type = datatypename(funcdef.return_type)


### PR DESCRIPTION
Fixes bug occured in Ceilometer V2 API doc:
http://docs.openstack.org/developer/ceilometer/webapi/v2.html#capabilities

The patch adds a blank line after the doc string, if no parameter is
specified and the last line of the description contains other characters
than whitspace. With this blank line the 'Return type' will be separated
from the doc string, so it will be formatted correctly.
