### PR TITLE
Fix Python3 compat

### DIFF
--- a/sphinxcontrib/pecanwsme/rest.py
+++ b/sphinxcontrib/pecanwsme/rest.py
@@ -25,6 +25,8 @@ from docutils import nodes
 from docutils.parsers import rst
 from docutils.statemachine import ViewList
 
+from functools import reduce
+
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.docstrings import prepare_docstring
 
@@ -53,7 +55,7 @@ def http_directive(method, path, content):
     :param content: Text describing the endpoint.
     """
     method = method.lower().strip()
-    if isinstance(content, basestring):
+    if isinstance(content, str):
         content = content.splitlines()
     yield ''
     yield '.. http:{method}:: {path}'.format(**locals())


### PR DESCRIPTION
This patch fixes 2 issues in Python 3:
- reduce() isn't available in the root namespace, but is available in the functools module (this is compatible with Python 2.6 / 2.7 as well).
- basestring is removed from Python 3, we must use str instead.