### PR TITLE
setup.cfg: Update with recent changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,15 @@
 [metadata]
 name = sphinxcontrib-pecanwsme
+summary = A Sphinx extension for documenting APIs built with Pecan and WSME
+description_file = README.rst
 author = Doug Hellmann
-author-email = doug.hellmann@dreamhost.com
-summary = Extension to Sphinx for documenting APIs built with Pecan and WSME
-description-file = README.rst
-license = Apache-2
+author_email = doug@doughellmann.com
+url = https://github.com/sphinx-contrib/pecanwsme
+project_urls =
+    Bug Tracker = https://github.com/sphinx-contrib/pecanwsme/issues
+    Source Code = https://github.com/sphinx-contrib/pecanwsme
 classifier =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Environment :: Console
     Intended Audience :: Developers
     Intended Audience :: Information Technology
@@ -16,17 +19,18 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: Software Development :: Documentation
+    Topic :: Documentation
+    Topic :: Documentation :: Sphinx
 keywords =
     documentation
     sphinx
-home-page = https://github.com/dreamhost/sphinxcontrib-pecanwsme
 
 [files]
-packages = 
+packages =
     sphinxcontrib
 namespace_packages =
     sphinxcontrib


### PR DESCRIPTION
- Use sphinx-contrib organization URLs
- Replace deprecated aliases with modern alternatives
- Drop support for Python 3.3, add support for 3.6
- Use more recent email address for the author

Signed-off-by: Stephen Finucane <stephen@that.guru>